### PR TITLE
Remove dependency on useful

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,8 +3,7 @@
   :license {:name "Eclipse Public License - v 1.0"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :description "Advanced classloading for clojure."
-  :dependencies [[org.clojure/clojure "1.4.0"]
-                 [useful "0.8.4-alpha2"]]
+  :dependencies [[org.clojure/clojure "1.4.0"]]
   :aliases {"testall" ["with-profile" "dev,default:dev,1.3,default:dev,1.5,default" "test"]}
   :profiles {:1.3 {:dependencies [[org.clojure/clojure "1.3.0"]]}
              :1.5 {:dependencies [[org.clojure/clojure "1.5.0-master-SNAPSHOT"]]}}

--- a/src/classlojure/core.clj
+++ b/src/classlojure/core.clj
@@ -1,6 +1,5 @@
 (ns classlojure.core
-  (:use [useful.java :only [invoke-private]]
-        [clojure.java.io :only [as-url]]
+  (:use [clojure.java.io :only [as-url]]
         [clojure.string :only [join]])
   (:import [java.net URL URLClassLoader]))
 
@@ -37,12 +36,6 @@
             ~@body
             (finally
              (.setContextClassLoader (Thread/currentThread) cl#))))))
-
-(defn append-classpath! [^URLClassLoader cl & urls]
-  (let [existing? (set (map #(.getPath ^URL %) (.getURLs cl)))]
-    (doseq [url urls]
-      (when-not (existing? url)
-        (invoke-private cl "addURL" (URL. url))))))
 
 (defn alter-java-library-path! [f & args]
   (let [field (.getDeclaredField ClassLoader "usr_paths")]

--- a/src/classlojure/io.clj
+++ b/src/classlojure/io.clj
@@ -1,7 +1,6 @@
 (ns classlojure.io
   (:use [classlojure.core :only [base-classloader]]
-        [clojure.java.io :only [copy file reader]]
-        [useful.utils :only [read-seq]])
+        [clojure.java.io :only [copy file reader]])
   (:import (java.io File FileInputStream)
            (java.net JarURLConnection)
            (clojure.lang LineNumberingPushbackReader)))
@@ -22,6 +21,15 @@
      (resource-reader base-classloader name))
   ([classloader name]
      (LineNumberingPushbackReader. (reader (resource-stream classloader name)))))
+
+;;; Taken from useful
+(defn read-seq
+  "Read all forms from *in* until an EOF is reached. Throws an exception on incomplete forms."
+  []
+  (lazy-seq
+   (let [form (read *in* false ::EOF)]
+     (when-not (= ::EOF form)
+       (cons form (read-seq))))))
 
 (defn resource-forms
   ([name]


### PR DESCRIPTION
Classlojure is often useful when we wish to control dependencies.  Having classlojure itself depend on useful (for a single function), broadens its footprint unnecessarily.
